### PR TITLE
Refactor usage of checking internal state

### DIFF
--- a/gfxmorph/meshfuncs.py
+++ b/gfxmorph/meshfuncs.py
@@ -3,20 +3,7 @@ import queue
 import numpy as np
 
 from . import maybe_pylinalg
-
-
-def make_vertex2faces(faces):
-    """Create a simple map to map vertex indices to a list of face indices."""
-    faces = np.asarray(faces, np.int32)
-    nverts = faces.max() + 1
-
-    vertex2faces = [[] for _ in range(nverts)]
-    for fi in range(len(faces)):
-        face = faces[fi]
-        vertex2faces[face[0]].append(fi)
-        vertex2faces[face[1]].append(fi)
-        vertex2faces[face[2]].append(fi)
-    return vertex2faces
+from .utils import make_vertex2faces
 
 
 def vertex_get_neighbours(faces, vertex2faces, vi):

--- a/gfxmorph/utils.py
+++ b/gfxmorph/utils.py
@@ -58,3 +58,18 @@ def as_immutable_array(array):
     v = array.view()
     v.setflags(write=False)
     return v
+
+
+def make_vertex2faces(faces, nverts=None):
+    """Create a simple map to map vertex indices to a list of face indices."""
+    faces = np.asarray(faces, np.int32)
+    if nverts is None:
+        nverts = faces.max() + 1
+
+    vertex2faces = [[] for _ in range(nverts)]
+    for fi in range(len(faces)):
+        face = faces[fi]
+        vertex2faces[face[0]].append(fi)
+        vertex2faces[face[1]].append(fi)
+        vertex2faces[face[2]].append(fi)
+    return vertex2faces

--- a/tests/test_basedynamicmesh.py
+++ b/tests/test_basedynamicmesh.py
@@ -122,8 +122,6 @@ class DynamicMesh(OriDynamicMesh):
     internal state is validated at each change. Plus we track changes
     and check them at each step too."""
 
-    _debug_mode = True
-
     def __init__(self):
         super().__init__()
         # Add a simple replicating tracker, to test that the overlapping API does proper replications
@@ -139,8 +137,8 @@ class DynamicMesh(OriDynamicMesh):
         self.tracker3 = MeshChangeTracker()
         self.track_changes(self.tracker3)
 
-    def _check_internal_state(self):
-        super()._check_internal_state()
+    def _after_change(self):
+        self.check_internal_state()
         if self.tracker1:
             assert np.all(self.faces == self.tracker1.faces)
             assert np.all(self.positions == self.tracker1.positions)


### PR DESCRIPTION
Basically some cleanup. I originally planned to use a `Tracker` to check the internal state of the mesh during the unit tests, but errors in trackers are caught and logged, so failed assertions happily pass :). Therefore I impemented a simple `_after_change` hook.