### PR TITLE
Add test in pop_vertices

### DIFF
--- a/example_undo.py
+++ b/example_undo.py
@@ -31,7 +31,7 @@ class MeshContainer:
         # The object that stores & manages the data
         self.dynamic_mesh = DynamicMesh(None, None)
 
-        #  Tracker that implement a todo stack
+        # Tracker that implement a todo stack
         self.undo_tracker = MeshUndoTracker()
         self.dynamic_mesh.track_changes(self.undo_tracker)
 

--- a/gfxmorph/basedynamicmesh.py
+++ b/gfxmorph/basedynamicmesh.py
@@ -472,7 +472,7 @@ class BaseDynamicMesh:
             self.swap_vertices(indices1, indices2)
 
         # Pop from the end
-        self.pop_vertices(len(to_delete))
+        self.pop_vertices(len(to_delete), _check_in_use=False)
 
     # %% The core API
 
@@ -733,7 +733,7 @@ class BaseDynamicMesh:
                 tracker.add_vertices(positions)
         self._after_change()
 
-    def pop_vertices(self, n, _old=None):
+    def pop_vertices(self, n, _old=None, *, _check_in_use=True):
         """Remove the last n vertices from the mesh."""
         vertex2faces = self._vertex2faces
 
@@ -749,6 +749,12 @@ class BaseDynamicMesh:
 
         nverts1 = len(self._positions)
         nverts2 = nverts1 - n
+
+        # Check that none of the vertices are in use.
+        # This step can be skipped if we already checked it (in delete_vertices).
+        if _check_in_use:
+            if any(len(vertex2faces[vi]) > 0 for vi in range(nverts2, nverts1)):
+                raise ValueError("Vertex to delete is in use.")
 
         # --- Apply
 

--- a/tests/test_basedynamicmesh.py
+++ b/tests/test_basedynamicmesh.py
@@ -556,9 +556,11 @@ def test_dynamicmesh_add_and_delete_verts():
 
     # Cannot delete vertex that is in use
     with pytest.raises(ValueError):
-        m.delete_vertices([0])  # Out of bounds
+        m.delete_vertices([0])
     with pytest.raises(ValueError):
-        m.delete_vertices([8])  # Out of bounds
+        m.delete_vertices([8])
+    with pytest.raises(ValueError):
+        m.pop_vertices(3)
 
     m.delete_faces([0, 1, 2])
 


### PR DESCRIPTION
Add a missing check in `pop_vertices` to prevent the mesh from becoming corrupted. This check was done in `delete_vertices`, but not in `pop_verticex`. 