### PR TITLE
Faster selection

### DIFF
--- a/example_morph.py
+++ b/example_morph.py
@@ -213,10 +213,12 @@ class Morpher:
         self.cancel()
         self.finish()
 
-        # Select vertices
+        # Select vertices.
+        # Use a (simpler, more performant) method when the radius is large
         search_distance = self.radius * 3  # 3 x std
+        method = "edge" if self.radius > 1.5 else "smooth2"
         indices, geodesic_distances = self.m.select_vertices_over_surface(
-            vii, ref_distances, search_distance
+            vii, ref_distances, search_distance, method
         )
         positions = self.m.positions[indices]
 

--- a/example_morph.py
+++ b/example_morph.py
@@ -214,9 +214,8 @@ class Morpher:
         self.finish()
 
         # Select vertices.
-        # Use a (simpler, more performant) method when the radius is large
         search_distance = self.radius * 3  # 3 x std
-        method = "edge" if self.radius > 1.5 else "smooth2"
+        method = "auto"  # method = "edge" if self.radius > 1.5 else "smooth2"
         indices, geodesic_distances = self.m.select_vertices_over_surface(
             vii, ref_distances, search_distance, method
         )

--- a/tests/test_dynamicmesh.py
+++ b/tests/test_dynamicmesh.py
@@ -227,6 +227,33 @@ def test_mesh_selection_basics():
     assert np.all(selected1 == selected2)
     assert len(selected1) == len(vertices)
 
+    # --
+
+    # Create a triangle that's on a line
+    vertices = [(0, 0, 0), (10, 0, 0), (-10, 0, 0)]
+    faces = [0, 1, 2]
+    m = DynamicMesh(vertices, faces)
+
+    # Select from the center vertex
+    selected, distances = m.select_vertices_over_surface(0, 0, 11)
+    assert len(selected) == 3
+    assert distances.tolist() == [0, 10, 10]
+
+    # Select from one side
+    selected, distances = m.select_vertices_over_surface(1, 0, 21)
+    assert len(selected) == 3
+    assert distances.tolist() == [10, 0, 20]
+
+    # Select from one side, plus offset
+    selected, distances = m.select_vertices_over_surface(1, 5, 30)
+    assert len(selected) == 3
+    assert distances.tolist() == [15, 5, 25]
+
+    # Select from in between
+    selected, distances = m.select_vertices_over_surface([0, 1], [5, 5], 30)
+    assert len(selected) == 3
+    assert distances.tolist() == [5, 5, 15]
+
 
 def test_mesh_path_distance():
     """This test validates the test_MeshPathSmooth2 class directly."""

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -168,6 +168,24 @@ def benchmark_sphere():
     print(t.measurements)
 
 
+def benchmark_selecting_vertices():
+    geo = smooth_sphere_geometry(100, subdivisions=5)
+    vertices = geo.positions.data
+    faces = geo.indices.data
+    m = DynamicMesh(vertices, faces)
+
+    for method in ["edge", "smooth1", "smooth2"]:
+        t0 = time.perf_counter()
+        verts, dists = m.select_vertices_over_surface(
+            0, 0, 100, distance_measure=method
+        )
+        t1 = time.perf_counter()
+        print(
+            f"Selecting {len(verts)}/{len(m.positions)} vertices using {method}: {t1-t0:0.3f}"
+        )
+
+
 if __name__ == "__main__":
-    benchmark()
+    # benchmark()
     # benchmark_sphere()
+    benchmark_selecting_vertices()

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -174,7 +174,7 @@ def benchmark_selecting_vertices():
     faces = geo.indices.data
     m = DynamicMesh(vertices, faces)
 
-    for method in ["edge", "smooth1", "smooth2"]:
+    for method in ["edge", "smooth1", "smooth2", "auto"]:
         t0 = time.perf_counter()
         verts, dists = m.select_vertices_over_surface(
             0, 0, 100, distance_measure=method


### PR DESCRIPTION
Observations:
* The selection of vertices seems to be a bottleneck. 
* The 'smooth2' geodesic distance is about 5x slower than the simple 'edge' method.
* The algorithm does quite a bit of duplicate work.

Done:
* Use a binary heap to avoid duplicate work. This makes the algorithm 2x faster for all distance measures.
* Introduce a new 'auto' method that uses the 'smooth2' until the cumulative distance is halfway the max distance (1.5x std), then falls back to 'edge'. This makes it about 2x faster again.

In total, the mesh selection is now about 5x faster.