### PR TITLE
Try improve behavior w.r.t. smoothing needle-like structures

### DIFF
--- a/example_morph.py
+++ b/example_morph.py
@@ -328,7 +328,6 @@ class Morpher:
                 self.state["xdirection"] * dxy[0] + self.state["ydirection"] * dxy[1]
             )
         else:
-            print("zz")
             return
 
         # Limit the displacement, so it can never be pulled beyond the vertices participarting in the morph.
@@ -383,7 +382,7 @@ class Morpher:
             for vi in s_indices
         ]
         s_curvatures = np.asarray(s_curvatures, np.float32)
-        print(s_curvatures.min(), s_curvatures.max())
+        # print(s_curvatures.min(), s_curvatures.max())
         curvature_smooth_factor = 100  # pretty arbitrary
         s_weights += np.abs(s_curvatures)[:, None] / curvature_smooth_factor
 
@@ -638,6 +637,10 @@ def on_mouse_3d(e):
     elif e.type == "wheel":
         if not morpher.state:
             morpher.radius *= 2 ** (e.dy / 500)
+            morpher.radius = min(
+                max(morpher.radius, 0.5 * morpher.ref_edge_length),
+                morpher.ref_edge_length * 20,
+            )
             face_index = e.pick_info["face_index"]
             face_coord = e.pick_info["face_coord"]
             morpher.show_morph_grab(face_index, face_coord)

--- a/example_morph.py
+++ b/example_morph.py
@@ -392,7 +392,6 @@ class Morpher:
             new_positions = np.zeros((len(s_indices), 3), np.float32)
             for i in range(len(s_indices)):
                 vi = s_indices[i]
-                p = positions[vi]
                 vii = list(vertex_get_neighbours(faces, vertex2faces, vi))
                 neighbour_positions = positions[vii]
                 new_positions[i] = neighbour_positions.mean(axis=0)

--- a/example_morph.py
+++ b/example_morph.py
@@ -12,7 +12,7 @@ import pygfx as gfx
 import pylinalg as la
 from gfxmorph.maybe_pygfx import smooth_sphere_geometry, DynamicMeshGeometry
 from gfxmorph import DynamicMesh, MeshUndoTracker
-from gfxmorph.meshfuncs import vertex_get_neighbours
+from gfxmorph.meshfuncs import vertex_get_neighbours, vertex_get_gaussian_curvature
 from gfxmorph.utils import logger
 
 
@@ -374,19 +374,33 @@ class Morpher:
         vertex2faces = self.m.vertex2faces
 
         s_indices = self.state["indices"]
-        s_weights = self.state["weights"]
+        s_positions = positions[s_indices]
+        s_weights = self.state["weights"].copy()
 
-        new_positions = np.zeros((len(s_indices), 3), np.float32)
-        for i in range(len(s_indices)):
-            vi = s_indices[i]
-            w = s_weights[i]
-            p = positions[vi]
-            vii = list(vertex_get_neighbours(faces, vertex2faces, vi))
-            p_delta = (positions[vii] - p).sum(axis=0) / len(vii)
-            new_positions[i] = p + p_delta * (w * smooth_factor)
+        if False:
+            # Calculate contribution of Gaussian curvature
+            s_curvatures = [
+                vertex_get_gaussian_curvature(positions, faces, vertex2faces, vi)
+                for vi in s_indices
+            ]
+            s_curvatures = np.asarray(s_curvatures, np.float32)
+            s_weights += np.abs(s_curvatures)[:, None] / 10
 
-        # Apply new positions
-        self.m.update_vertices(s_indices, new_positions)
+        if True:
+            # Laplacian smoothing
+
+            new_positions = np.zeros((len(s_indices), 3), np.float32)
+            for i in range(len(s_indices)):
+                vi = s_indices[i]
+                p = positions[vi]
+                vii = list(vertex_get_neighbours(faces, vertex2faces, vi))
+                neighbour_positions = positions[vii]
+                new_positions[i] = neighbour_positions.mean(axis=0)
+
+        s_weights[s_weights > 1] = 1
+        self.m.update_vertices(
+            s_indices, new_positions * s_weights + s_positions * (1 - s_weights)
+        )
 
     def finish(self):
         """Stop the morph or smooth action and commit the result."""
@@ -400,29 +414,51 @@ class Morpher:
             # self.geometry.sizes.data[indices] = 0
             # self.geometry.sizes.update_range(first, last - first + 1)
             # Commit or cancel
-            if self.m.is_manifold:
+            action = self.state["action"]
+            problems = self._get_mesh_problems()
+            if not problems:
                 self._smooth_some(0.1)
                 self.commit()
             else:
                 self.cancel()
+                logger.warn(f"Discarding {action} since it made the mesh {problems}.")
             # Post-processing
-            if self.state["action"] == "morph" and self.m.is_manifold:
+            if not self._get_mesh_problems():
                 self.m.resample_selection(
                     self.state["indices"], self.state["weights"], self.ref_edge_length
                 )
-                if self.m.is_manifold:
+                problems = self._get_mesh_problems()
+                if not problems:
                     self.undo_tracker.commit_amend()
                 else:
-                    # Ideally this never happens, but it's a failsafe. At time of writing, it actually happens sometimes.
+                    # Ideally this never happens, but it's a failsafe.
+                    # At time of writing, it actually happens sometimes. In
+                    # particular for needle-like structures. This is anoying, since
+                    # these therefore don't get resampled, so the mesh stays very
+                    # fine-grained, and the smoothing has little effect, which
+                    # contributes to needle-like objects being hard to get rid off.
                     self.cancel()
                     logger.warn(
-                        "Discarding resampling step because it made the mesh non-manifold"
+                        f"Discarding resampling after {action} since it made the mesh {problems}."
                     )
             # todo: sometimes faces are missing or weird faces occur, due to the faces data not being synced correctlty
             # -> I've looked into why this happens but have not been able to find the cause.
             # -> Let's revisit when we implement a more efficient way to do the updates.
             self.geometry.indices.update_range()
             self.state = None
+
+    def _get_mesh_problems(self):
+        problems = []
+        if not self.m.is_manifold:
+            problems.append("non-manifold")
+        if not self.m.is_closed:
+            problems.append("not-closed")
+        if not self.m.is_oriented:
+            problems.append("not-oriented")
+        if problems:
+            return ", ".join(problems)
+        else:
+            return None
 
 
 morpher = Morpher()

--- a/example_morph.py
+++ b/example_morph.py
@@ -377,24 +377,23 @@ class Morpher:
         s_positions = positions[s_indices]
         s_weights = self.state["weights"].copy()
 
-        if False:
-            # Calculate contribution of Gaussian curvature
-            s_curvatures = [
-                vertex_get_gaussian_curvature(positions, faces, vertex2faces, vi)
-                for vi in s_indices
-            ]
-            s_curvatures = np.asarray(s_curvatures, np.float32)
-            s_weights += np.abs(s_curvatures)[:, None] / 10
+        # Calculate contribution of Gaussian curvature
+        s_curvatures = [
+            vertex_get_gaussian_curvature(positions, faces, vertex2faces, vi)
+            for vi in s_indices
+        ]
+        s_curvatures = np.asarray(s_curvatures, np.float32)
+        print(s_curvatures.min(), s_curvatures.max())
+        curvature_smooth_factor = 100  # pretty arbitrary
+        s_weights += np.abs(s_curvatures)[:, None] / curvature_smooth_factor
 
-        if True:
-            # Laplacian smoothing
-
-            new_positions = np.zeros((len(s_indices), 3), np.float32)
-            for i in range(len(s_indices)):
-                vi = s_indices[i]
-                vii = list(vertex_get_neighbours(faces, vertex2faces, vi))
-                neighbour_positions = positions[vii]
-                new_positions[i] = neighbour_positions.mean(axis=0)
+        # Laplacian smoothing
+        new_positions = np.zeros((len(s_indices), 3), np.float32)
+        for i in range(len(s_indices)):
+            vi = s_indices[i]
+            vii = list(vertex_get_neighbours(faces, vertex2faces, vi))
+            neighbour_positions = positions[vii]
+            new_positions[i] = neighbour_positions.mean(axis=0)
 
         s_weights[s_weights > 1] = 1
         self.m.update_vertices(

--- a/gfxmorph/basedynamicmesh.py
+++ b/gfxmorph/basedynamicmesh.py
@@ -551,7 +551,7 @@ class BaseDynamicMesh:
                 vertex2faces[face[2]].append(fi)
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -598,7 +598,7 @@ class BaseDynamicMesh:
             self._deallocate_faces(n)
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -663,7 +663,7 @@ class BaseDynamicMesh:
                 a[indices1], a[indices2] = a[indices2], a[indices1]
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -717,7 +717,7 @@ class BaseDynamicMesh:
             self._update_face_normals(indices)
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -753,7 +753,7 @@ class BaseDynamicMesh:
             vertex2faces.extend([] for i in range(n))
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -798,7 +798,7 @@ class BaseDynamicMesh:
             vertex2faces[nverts2:] = []
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -855,7 +855,7 @@ class BaseDynamicMesh:
                 )
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify
@@ -897,7 +897,7 @@ class BaseDynamicMesh:
             self._update_face_normals(list(face_indices))
 
         except Exception:  # pragma: no cover
-            logger.warn(EXCEPTION_IN_ATOMIC_CODE)
+            logger.warning(EXCEPTION_IN_ATOMIC_CODE)
             raise
 
         # --- Notify

--- a/gfxmorph/mesh.py
+++ b/gfxmorph/mesh.py
@@ -549,7 +549,7 @@ class DynamicMesh(BaseDynamicMesh):
         if not faces_to_remove:
             # This is a standalone vertex
             return vertices_to_remove, [], []
-        elif len(faces_to_remove) <= 3:
+        elif len(faces_to_remove) < 3:
             # This vertex is on a boundary, we can just remove the faces!
             return vertices_to_remove, faces_to_remove, []
 

--- a/gfxmorph/mesh.py
+++ b/gfxmorph/mesh.py
@@ -224,7 +224,7 @@ class DynamicMesh(BaseDynamicMesh):
 
         """
 
-        # todo: I've observed this algorithm to sometimes produces a non-manifold mesh for small components.
+        # todo: I've observed this algorithm to sometimes produces a non-manifold mesh for small/pointy components.
 
         positions = self.positions
         faces = self.faces
@@ -250,7 +250,7 @@ class DynamicMesh(BaseDynamicMesh):
         # X---------X---------X
         #
         # Note that the loosen factor (depending on weight) helps
-        # prevent near-degenerate triangles that can normally can occur
+        # prevent near-degenerate triangles that can normally occur
         # near the boundary of the selection.
 
         # Note: A method that we could have used but don't, is to pop
@@ -289,28 +289,17 @@ class DynamicMesh(BaseDynamicMesh):
         too_long.sort(key=lambda x: -x[0])
         too_short.sort(key=lambda x: x[0])
 
-        # Next, we take a few steps to determine what edges we split,
-        # and what vertices we will pop. In this process, we keep track
-        # of the faces that effected by the planned changes so far.
-        # This is to prevent changes to clash and create a corrupt mesh.
+        # Next, we take a few steps to determine what edges we want to
+        # split, and what vertices we want to pop.
         #
-        # This means that some edges which are too short or too long
-        # are not handled in this call. Though the worst cases are
-        # prioritized. It is somewhat assumed that this method is called
-        # in an interactive setting. If necessary, a new subset can be
-        # selected and resampled.
-        #
-        # Another solution is to apply each change separetely, but this
-        # results in relatively large undo stacks.
-        affected_faces = set()
+        # Note that not all changes may be actually applied, see below.
+
+        vertices_to_pop = []
+        edges_to_split = []
 
         # Determine vertices incident to edges that are too long.
-        edges_to_split = []
         for d, vi1, vi2 in too_long:
-            touched_faces = set(vertex2faces[vi1]) & set(vertex2faces[vi2])
-            if not (touched_faces & affected_faces):
-                affected_faces.update(touched_faces)
-                edges_to_split.append((vi1, vi2))
+            edges_to_split.append((vi1, vi2))
 
         # Determine vertices that connect multiple edges that are too short.
         too_short_vertices = {}
@@ -323,12 +312,8 @@ class DynamicMesh(BaseDynamicMesh):
         hot_vertices.sort(reverse=True)
 
         # We will pop the ones that we can
-        vertices_to_pop = []
         for _, vi in hot_vertices:
-            touched_faces = set(vertex2faces[vi])
-            if not (touched_faces & affected_faces):
-                affected_faces.update(touched_faces)
-                vertices_to_pop.append(vi)
+            vertices_to_pop.append(vi)
 
         # And we also pop one vertex of the other too-short-edges, preferring
         # the ones with the most neighbours, to avoid star-like structures.
@@ -338,44 +323,54 @@ class DynamicMesh(BaseDynamicMesh):
             vii = vi1, vi2
             if len(vertex2faces[vi1]) < len(vertex2faces[vi2]):
                 vii = vi2, vi1
-            for vi in vii:
-                touched_faces = set(vertex2faces[vi])
-                if not (touched_faces & affected_faces):
-                    affected_faces.update(touched_faces)
-                    vertices_to_pop.append(vi)
-                    break
+            vertices_to_pop.extend(vii)
 
         # Next we collect the changes, so we can apply them in one go...
-        vertices_to_remove = []
+        #
+        # Changes that affect vertices or faces that were already
+        # affected by earlier changes are discarded. This means that
+        # some edges which are too short or too long are not handled
+        # in this call. Though the worst cases are prioritized. It is
+        # somewhat assumed that this method is called in an interactive
+        # setting. If necessary, a new subset can be selected and
+        # resampled.
+
+        vertices_to_remove = set()
         vertices_to_add = []
-        faces_to_remove = []
+        faces_to_remove = set()
         faces_to_add = []
+
+        # Changes to make the mesh more coarse
+        for vi in vertices_to_pop:
+            try:
+                r_verts, r_faces, a_faces = self._erase_vertex(vi, faces_to_remove)
+            except RuntimeError as err:
+                logger.warning(str(err))
+                continue
+            if vertices_to_remove.intersection(r_verts):
+                continue
+            if faces_to_remove.intersection(r_faces):
+                continue
+            vertices_to_remove.update(r_verts)
+            faces_to_remove.update(r_faces)
+            faces_to_add.extend(a_faces)
 
         # Changes to make the mesh more detailed
         for vi1, vi2 in edges_to_split:
             new_index = len(self.positions) + len(vertices_to_add)
             a_verts, r_faces, a_faces = self._split_edge(vi1, vi2, new_index)
-            vertices_to_add.extend(a_verts)
-            faces_to_remove.extend(r_faces)
-            faces_to_add.extend(a_faces)
-
-        # Changes to make the mesh more coarse
-        for vi in vertices_to_pop:
-            try:
-                r_verts, r_faces, a_faces = self._erase_vertex(vi)
-            except RuntimeError as err:
-                logger.warn(str(err))
+            if faces_to_remove.intersection(r_faces):
                 continue
-            vertices_to_remove.extend(r_verts)
-            faces_to_remove.extend(r_faces)
+            vertices_to_add.extend(a_verts)
+            faces_to_remove.update(r_faces)
             faces_to_add.extend(a_faces)
 
         # Apply changes
         if len(vertices_to_add) > 0:
             self.add_vertices(vertices_to_add)
-        self.delete_and_add_faces(faces_to_remove, faces_to_add)
+        self.delete_and_add_faces(list(faces_to_remove), faces_to_add)
         if len(vertices_to_remove) > 0:
-            self.delete_vertices(vertices_to_remove)
+            self.delete_vertices(list(vertices_to_remove))
 
     def split_edge(self, vi1, vi2):
         """Add a vertex on the give edge.
@@ -500,7 +495,7 @@ class DynamicMesh(BaseDynamicMesh):
         try:
             vertices_to_remove, faces_to_remove, faces_to_add = self._erase_vertex(vi)
         except RuntimeError as err:
-            logger.warn(str(err))
+            logger.warning(str(err))
             return
 
         # Apply changes
@@ -511,7 +506,7 @@ class DynamicMesh(BaseDynamicMesh):
         if len(vertices_to_remove) > 0:
             self.delete_vertices(vertices_to_remove)
 
-    def _erase_vertex(self, vi):
+    def _erase_vertex(self, vi, _faces_that_no_longer_exist=None):
         # This code:
         #
         # - Obtains the faces incident to the vertex to remove.
@@ -531,6 +526,8 @@ class DynamicMesh(BaseDynamicMesh):
         faces = self.faces
         vertex2faces = self.vertex2faces
 
+        faces_that_no_longer_exist = _faces_that_no_longer_exist or set()
+
         vi_to_remove = int(vi)
         vertices_to_remove = [vi_to_remove]
         faces_to_remove = list(vertex2faces[vi_to_remove])
@@ -542,7 +539,7 @@ class DynamicMesh(BaseDynamicMesh):
         nearby_faces = set()
         for vi in vii:
             nearby_faces.update(vertex2faces[vi])
-        context_faces = nearby_faces - set(faces_to_remove)
+        context_faces = nearby_faces - set(faces_to_remove) - faces_that_no_longer_exist
 
         # If no faces remain in this component, we dont pop the vertex
         if not context_faces:
@@ -552,7 +549,7 @@ class DynamicMesh(BaseDynamicMesh):
         if not faces_to_remove:
             # This is a standalone vertex
             return vertices_to_remove, [], []
-        elif len(faces_to_remove) <= 2:
+        elif len(faces_to_remove) <= 3:
             # This vertex is on a boundary, we can just remove the faces!
             return vertices_to_remove, faces_to_remove, []
 
@@ -562,7 +559,7 @@ class DynamicMesh(BaseDynamicMesh):
         # face means that we have a tetrahedron which we dont want to
         # reduce. This rule means that if (this component of) the mesh
         # is not closed, we cannot reduce components further than 4
-        # faces, but that's probably fine (deteting this case is
+        # faces, but that's probably fine (detecting this case is
         # relatively expensive).
         if len(context_faces) <= 1:
             return [], [], []

--- a/tests/test_dynamicmesh.py
+++ b/tests/test_dynamicmesh.py
@@ -116,7 +116,7 @@ def test_split_edge():
         m.split_edge(5, 28)
 
 
-def test_erase_vertex():
+def test_erase_vertex1():
     # Create a silly mesh consisting of a quad
     quad = [[0, 0, 0], [0, 0, 1], [0, 1, 1], [0, 1, 0]]
     m = DynamicMesh(quad, [[0, 1, 2], [0, 2, 3]])
@@ -148,6 +148,111 @@ def test_erase_vertex():
         assert len(m.faces) == 58
         assert m.is_manifold
         assert m.is_closed
+
+
+def test_erase_vertex2():
+    # Create a shape that I expect will be present at the end of a needle-like object.
+    # Basically a triangular base, with a prism on top.
+    positions = [
+        # left triangle
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        # right triangle
+        [2, 0, 0],
+        [2, 1, 0],
+        [2, 0, 1],
+        # tip
+        [4, 0.5, 0.5],
+    ]
+
+    faces = [
+        # bottom
+        [0, 2, 1],
+        # body
+        [0, 4, 3],
+        [0, 1, 4],
+        [1, 5, 4],
+        [1, 2, 5],
+        [0, 3, 5],
+        [0, 5, 2],
+        # tip
+        [3, 4, 6],
+        [4, 5, 6],
+        [5, 3, 6],
+    ]
+
+    m = DynamicMesh(positions, faces)
+
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+    # Remove a vertex near the tip. The tip now moves to position 3
+    m.erase_vertex(3)
+    assert len(m.positions) == 6
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+    # Another one
+    m.erase_vertex(5)
+    assert len(m.positions) == 5
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+    # And remove the tip ...
+    m.erase_vertex(3)
+    assert len(m.positions) == 4
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+
+def test_erase_vertex3():
+    positions = [
+        # left tip
+        [0, 0.5, 0.5],
+        # triangle
+        [2, 0, 0],
+        [2, 1, 0],
+        [2, 0, 1],
+        # right tip
+        [4, 0.5, 0.5],
+    ]
+
+    faces = [
+        # left tip
+        [0, 2, 1],
+        [0, 3, 2],
+        [0, 1, 3],
+        # right tip
+        [4, 1, 2],
+        [4, 2, 3],
+        [4, 3, 1],
+    ]
+
+    m = DynamicMesh(positions, faces)
+
+    assert len(m.positions) == 5
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+    # Remove close to tip
+    m.erase_vertex(3)
+    assert len(m.positions) == 4
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
+
+    # Removing the tip does not work, otherwise it'd collapse
+    m.erase_vertex(3)
+    assert len(m.positions) == 4
+    assert m.is_manifold
+    assert m.is_closed
+    assert m.is_oriented
 
 
 def test_erase_vertex_does_not_remove_a_component():


### PR DESCRIPTION
### The problem

It is possible to morph+smooth a part of the mesh into a very pointy structure that can be hard to remove. Reasons why it gets hard to remove:
* The tip gets so pointy that you cannot really morph it "into the main shape" anymore.
* Smoothing the tip moves the tip inward, but also elongates the pointy structure from the wide end.
* At some point, the resampling step causes the mesh to become corrupt, so the resampling is cancelled, so the triangles stay small, and the structure does not move much when smoothing it.

### Attempts

In this PR I tried a few different things to mitigate this. Things may be a bit (?) better, but the issue is not solved at all 😞 
* I implemented a function to calculate the Gaussian curvature. Ok, this bit by itself may be of use at some point, so there's that 😄 .
* Using the curvature to remove the vertices that form the tip of a needle during resampling ... does not really seem to help.
* Using the curvature and surface normals during smoothing to push pointy objects back ... gets out of control real quick.
* Using the curvature to smooth high-curvature objects harder ... seems to help a bit.
* Trying to cover the case in resampling where the mesh is made non-manifold ... I have put several measures in place, wrote some unit tests, but I have not been able to find the cause.

### Ideas

* Implement edge-popping (merging two faces) instead of popping a vertex and filling the hole. This is less invasive so it may fix the case that the mesh is made non-manifold. In Arbiter I made notes that this approach had a tendency to sometimes created somewhat folded faces, but it may be worth another look.
