### PR TITLE
Resampling by popping edges

### DIFF
--- a/example_morph.py
+++ b/example_morph.py
@@ -418,7 +418,9 @@ class Morpher:
                 self.commit()
             else:
                 self.cancel()
-                logger.warn(f"Discarding {action} since it made the mesh {problems}.")
+                logger.warning(
+                    f"Discarding {action} since it made the mesh {problems}."
+                )
             # Post-processing
             if not self._get_mesh_problems():
                 self.m.resample_selection(
@@ -435,7 +437,7 @@ class Morpher:
                     # fine-grained, and the smoothing has little effect, which
                     # contributes to needle-like objects being hard to get rid off.
                     self.cancel()
-                    logger.warn(
+                    logger.warning(
                         f"Discarding resampling after {action} since it made the mesh {problems}."
                     )
             # todo: sometimes faces are missing or weird faces occur, due to the faces data not being synced correctlty

--- a/example_morph.py
+++ b/example_morph.py
@@ -372,16 +372,19 @@ class Morpher:
         positions = self.m.positions
         vertex2faces = self.m.vertex2faces
 
+        # Calculate curvaturs, but only once to safe time
+        if "curvatures" not in self.state:
+            s_curvatures = [
+                vertex_get_gaussian_curvature(positions, faces, vertex2faces, vi)
+                for vi in self.state["indices"]
+            ]
+            self.state["curvatures"] = np.asarray(s_curvatures, np.float32)
+
         s_indices = self.state["indices"]
         s_positions = positions[s_indices]
         s_weights = self.state["weights"].copy()
+        s_curvatures = self.state["curvatures"]
 
-        # Calculate contribution of Gaussian curvature
-        s_curvatures = [
-            vertex_get_gaussian_curvature(positions, faces, vertex2faces, vi)
-            for vi in s_indices
-        ]
-        s_curvatures = np.asarray(s_curvatures, np.float32)
         # print(s_curvatures.min(), s_curvatures.max())
         curvature_smooth_factor = 100  # pretty arbitrary
         s_weights += np.abs(s_curvatures)[:, None] / curvature_smooth_factor

--- a/gfxmorph/mesh.py
+++ b/gfxmorph/mesh.py
@@ -15,6 +15,7 @@
 import heapq
 
 import numpy as np
+import pylinalg as la
 
 from .basedynamicmesh import BaseDynamicMesh
 from .utils import logger
@@ -495,6 +496,26 @@ class DynamicMesh(BaseDynamicMesh):
 
         return [new_position], faces2split, new_faces
 
+    def merge_edge(self, vi1, vi2):
+        """Remove the given edge.
+
+        This removes the edge between vi1 and vi2, and the two faces
+        that contain that edge. Results in 1 less vertex, 2 less faces,
+        3 less edges.
+        """
+        # Do the algorithmic
+        vertices_to_remove, faces_to_remove, faces_to_add = self._merge_edge(
+            vi1, vi2, len(self.positions)
+        )
+
+        # Apply changes
+        if len(vertices_to_remove) > 0:
+            self.remove_vertices(vertices_to_remove)
+        if len(faces_to_add) > 0:
+            self.add_faces(faces_to_add)
+        if len(faces_to_remove) > 0:
+            self.delete_faces(faces_to_remove)
+
     def _merge_edge(self, vi1, vi2, _forbidden_faces=None):
         positions = self.positions
         faces = self.faces
@@ -502,13 +523,15 @@ class DynamicMesh(BaseDynamicMesh):
 
         forbidden_faces = _forbidden_faces or set()
 
-        fii1 = vertex2faces[vi1]
-        fii2 = vertex2faces[vi2]
+        fii1 = set(vertex2faces[vi1])
+        fii2 = set(vertex2faces[vi2])
 
-        if forbidden_faces.intersection(fii1) or forbidden_faces.intersection(fii2):
+        if fii1.intersection(forbidden_faces) or fii2.intersection(forbidden_faces):
             return [], [], []
 
-        faces_to_remove = set(fii1) & set(fii2)
+        faces_overlap = fii1 & fii2
+        faces_to_adjust1 = fii1 - faces_overlap
+        faces_to_adjust2 = fii2 - faces_overlap
 
         # Vertices that are on an edge with the two vertices to merge
         secondary_verts1 = meshfuncs.vertex_get_neighbours(faces, vertex2faces, vi1)
@@ -517,37 +540,71 @@ class DynamicMesh(BaseDynamicMesh):
         # Edges (represented here as vertices) that get collapsed
         edges_being_collapsed = set(secondary_verts1) & set(secondary_verts2)
 
-        if len(faces_to_remove) != 2:
+        if len(faces_overlap) != 2:
             return [], [], []
         if len(edges_being_collapsed) != 2:
             return [], [], []
 
-        # todo: determine best way to collapse
+        def get_face_normals(sub_faces):
+            r1 = positions[sub_faces[:, 0], :]
+            r2 = positions[sub_faces[:, 1], :]
+            r3 = positions[sub_faces[:, 2], :]
+            face_normals = np.cross((r2 - r1), (r3 - r1))  # assumes CCW
+            norms = np.linalg.norm(face_normals, axis=1)
+            (zeros,) = np.where(norms == 0)
+            norms[zeros] = 1.0  # prevent divide-by-zero
+            face_normals /= norms[:, np.newaxis]
+            face_normals[zeros] = 0.0
+            return face_normals
 
-        if True:
-            # Remove vi1
-            vertices_to_remove = [vi1]
-            faces_to_remove.update(fii1)
+        normals1 = get_face_normals(faces[list(faces_to_adjust1)])
+        normals2 = get_face_normals(faces[list(faces_to_adjust2)])
 
-            face_to_add = []
-            for fi in fii1:
-                if fi in fii2:
-                    continue
-                a, b, c = faces[fi]
-                if a == vi1:
-                    face_to_add.append((vi2, b, c))
-                elif b == vi1:
-                    face_to_add.append((a, vi2, c))
-                elif c == vi1:
-                    face_to_add.append((a, b, vi2))
-                else:
-                    assert False, "WTF"
-        else:
-            # Remove vi2
-            1 / 0
-            # xx -> put it in between
+        options = []
 
-        return vertices_to_remove, faces_to_remove, face_to_add
+        # Option 1: remove vi1
+        vertices_to_remove = [vi1]
+        faces_to_remove = list(fii1)
+        face_to_add = []
+        for fi in faces_to_adjust1:
+            a, b, c = faces[fi]
+            if a == vi1:
+                face_to_add.append((vi2, b, c))
+            elif b == vi1:
+                face_to_add.append((a, vi2, c))
+            elif c == vi1:
+                face_to_add.append((a, b, vi2))
+            else:
+                assert False, "WTF"
+        # Measure score
+        normals1_new = get_face_normals(np.array(face_to_add, np.int32))
+        score = 1 / (la.vec_angle(normals1, normals1_new).max() + 1e-9)
+        options.append((score, vertices_to_remove, faces_to_remove, face_to_add))
+
+        # Option 2: remove vi2
+        vertices_to_remove = [vi2]
+        faces_to_remove = list(fii2)
+        face_to_add = []
+        for fi in faces_to_adjust2:
+            a, b, c = faces[fi]
+            if a == vi2:
+                face_to_add.append((vi1, b, c))
+            elif b == vi2:
+                face_to_add.append((a, vi1, c))
+            elif c == vi2:
+                face_to_add.append((a, b, vi1))
+            else:
+                assert False, "WTF"
+        # Measure score
+        normals2_new = get_face_normals(np.array(face_to_add, np.int32))
+        score = 1 / (la.vec_angle(normals2, normals2_new).max() + 1e-9)
+        options.append((score, vertices_to_remove, faces_to_remove, face_to_add))
+
+        # todo: Option 3: pick a point (somewhere) in between vi1 and vi2
+
+        # Select the best option (with the highest score)
+        options.sort()
+        return options[-1][1:]
 
     # todo: naming things .. we already have pop_vertices!
 


### PR DESCRIPTION
Make the mesh coarser by collapsing edges, instead of removing vertices and re-tesselating. This code path is much easier to implement and more performant. Where in Arbiter the remaining vertex was positioned in between the two original positions, the current implementation picks a side, by calculating both versions and scoring them (by the angular change of the normals), as to avoid extreme folding of faces.

From what I've seen, it certainly reduce the number of times that I see the mesh getting non-manifold, but it does not completely eliminate it.

Paper that describes collapsing edges and scoring the options:
[RameshCleanerPaper.pdf](https://github.com/pygfx/gfxmorph/files/12767800/RameshCleanerPaper.pdf)
